### PR TITLE
added POST /upload API

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -11,6 +11,7 @@ package configuration
 
 import (
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/NethServer/nethsecurity-api/logs"
@@ -27,6 +28,9 @@ type Configuration struct {
 	StaticDir string `json:"static_dir"`
 
 	SensitiveList []string `json:"sensitive_list"`
+
+	UploadFileMaxSize int64  `json:"upload_file_max_size"`
+	UploadFilePath    string `json:"upload_file_path"`
 }
 
 var Config = Configuration{}
@@ -76,5 +80,17 @@ func Init() {
 		Config.SensitiveList = strings.Split(os.Getenv("SENSITIVE_LIST"), ",")
 	} else {
 		Config.SensitiveList = []string{"password", "secret", "token"}
+	}
+
+	if os.Getenv("UPLOAD_FILE_PATH") != "" {
+		Config.UploadFilePath = os.Getenv("UPLOAD_FILE_PATH")
+	} else {
+		Config.UploadFilePath = "/var/run/nethsecurity-api/uploads"
+	}
+
+	if os.Getenv("UPLOAD_FILE_MAX_SIZE") != "" {
+		Config.UploadFileMaxSize, _ = strconv.ParseInt(os.Getenv("UPLOAD_FILE_MAX_SIZE"), 10, 64)
+	} else {
+		Config.UploadFileMaxSize = 32
 	}
 }

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -73,7 +73,7 @@ func Init() {
 	if os.Getenv("STATIC_DIR") != "" {
 		Config.StaticDir = os.Getenv("STATIC_DIR")
 	} else {
-		Config.StaticDir = "/var/run/nethsecurity-api"
+		Config.StaticDir = "/var/run/ns-api-server"
 	}
 
 	if os.Getenv("SENSITIVE_LIST") != "" {
@@ -85,7 +85,7 @@ func Init() {
 	if os.Getenv("UPLOAD_FILE_PATH") != "" {
 		Config.UploadFilePath = os.Getenv("UPLOAD_FILE_PATH")
 	} else {
-		Config.UploadFilePath = "/var/run/nethsecurity-api/uploads"
+		Config.UploadFilePath = "/var/run/ns-api-server/uploads"
 	}
 
 	if os.Getenv("UPLOAD_FILE_MAX_SIZE") != "" {

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/gin-contrib/static v0.0.1
 	github.com/gin-gonic/gin v1.9.0
 	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/google/uuid v1.2.0
 	github.com/nqd/flat v0.2.0
 	github.com/pkg/errors v0.9.1
 )

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,7 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=

--- a/main.go
+++ b/main.go
@@ -93,6 +93,9 @@ func main() {
 		api.GET("/2fa", methods.Get2FAStatus)
 		api.DELETE("/2fa", methods.Del2FAStatus)
 		api.GET("/2fa/qr-code", methods.QRCode)
+
+		// upload
+		api.POST("/upload", methods.Upload)
 	}
 
 	// handle missing endpoint

--- a/methods/upload.go
+++ b/methods/upload.go
@@ -12,7 +12,6 @@ package methods
 import (
 	"net/http"
 	"os"
-	"path/filepath"
 
 	"github.com/NethServer/nethsecurity-api/configuration"
 	"github.com/NethServer/nethsecurity-api/response"
@@ -44,11 +43,8 @@ func Upload(c *gin.Context) {
 	// create directory if not exists
 	_ = os.MkdirAll(configuration.Config.UploadFilePath, os.ModePerm)
 
-	// get filename
-	filename := filepath.Base(file.Filename)
-
 	// set name with uuid to avoid overrides
-	name := filename + "-" + uuid.New().String()
+	name := "upload-" + uuid.New().String()
 
 	// upload the file to specific directory and check error
 	if err := c.SaveUploadedFile(file, configuration.Config.UploadFilePath+"/"+name); err != nil {

--- a/methods/upload.go
+++ b/methods/upload.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2023 Nethesis S.r.l.
+ * http://www.nethesis.it - info@nethesis.it
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ * author: Edoardo Spadoni <edoardo.spadoni@nethesis.it>
+ */
+
+package methods
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/NethServer/nethsecurity-api/configuration"
+	"github.com/NethServer/nethsecurity-api/response"
+	"github.com/google/uuid"
+
+	"github.com/fatih/structs"
+	"github.com/gin-gonic/gin"
+)
+
+func Upload(c *gin.Context) {
+	//check limit size
+	var w http.ResponseWriter = c.Writer
+	c.Request.Body = http.MaxBytesReader(w, c.Request.Body, configuration.Config.UploadFileMaxSize*1024*1024)
+	c.Next()
+
+	// get file
+	file, err := c.FormFile("file")
+
+	// check error
+	if err != nil {
+		c.JSON(http.StatusBadRequest, structs.Map(response.StatusBadRequest{
+			Code:    400,
+			Message: "file upload error. error on upload",
+			Data:    err.Error(),
+		}))
+		return
+	}
+
+	// create directory if not exists
+	_ = os.MkdirAll(configuration.Config.UploadFilePath, os.ModePerm)
+
+	// get filename
+	filename := filepath.Base(file.Filename)
+
+	// set name with uuid to avoid overrides
+	name := filename + "-" + uuid.New().String()
+
+	// upload the file to specific directory and check error
+	if err := c.SaveUploadedFile(file, configuration.Config.UploadFilePath+"/"+name); err != nil {
+		c.JSON(http.StatusBadRequest, structs.Map(response.StatusBadRequest{
+			Code:    400,
+			Message: "file upload error. error on save",
+			Data:    err.Error(),
+		}))
+		return
+	}
+
+	// return status ok
+	c.JSON(http.StatusOK, structs.Map(response.StatusOK{
+		Code:    200,
+		Message: "file upload success",
+		Data:    name,
+	}))
+}


### PR DESCRIPTION
Added POST /upload API to allow file uploading. The API path and max file size can be customized by 2 ENV var:
- `UPLOAD_FILE_PATH`: The directory where the files are uploaded. If the directory does not exists the server creates it. Default: `/var/run/nethsecurity-api/uploads`
- `UPLOAD_FILE_MAX_SIZE`:  The maximum size of files to upload.  If the size exceeds the API returns a specific error. Default `32` (32MB).

To test:
```bash
curl -X POST http://<server_ip>:<server_port>/api/upload -F "file=@<your_local_file>" -H "Content-Type: multipart/form-data"
```