### PR TITLE
2fa. handle recovery codes on GET /2fa

### DIFF
--- a/methods/auth.go
+++ b/methods/auth.go
@@ -268,7 +268,7 @@ func Get2FAStatus(c *gin.Context) {
 	c.JSON(http.StatusOK, structs.Map(response.StatusOK{
 		Code:    200,
 		Message: message,
-		Data:    gin.H{"status": statusS == "1", "codes": recoveryCodes},
+		Data:    gin.H{"status": statusS == "1", "recovery_codes": recoveryCodes},
 	}))
 }
 

--- a/methods/auth.go
+++ b/methods/auth.go
@@ -304,6 +304,17 @@ func Del2FAStatus(c *gin.Context) {
 		return
 	}
 
+	// revocate recovery codes
+	errRevocateCodes := os.Remove(configuration.Config.SecretsDir + "/" + claims["id"].(string) + "/codes")
+	if errRevocateCodes != nil {
+		c.JSON(http.StatusBadRequest, structs.Map(response.StatusBadRequest{
+			Code:    403,
+			Message: "error in delete 2FA recovery codes",
+			Data:    nil,
+		}))
+		return
+	}
+
 	// set 2FA to disabled
 	f, _ := os.OpenFile(configuration.Config.SecretsDir+"/"+claims["id"].(string)+"/status", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	defer f.Close()

--- a/methods/auth.go
+++ b/methods/auth.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/Jeffail/gabs/v2"
 	jwt "github.com/appleboy/gin-jwt/v2"
 	"github.com/dgryski/dgoogauth"
 	"github.com/fatih/structs"
@@ -107,10 +108,24 @@ func OTPVerify(c *gin.Context) {
 		recoveryCodes := GetRecoveryCodes(jsonOTP.Username)
 
 		if !utils.Contains(jsonOTP.OTP, recoveryCodes) {
+			// compose validation error
+			jsonParsed, _ := gabs.ParseJSON([]byte(`{
+				"validation": {
+				  "errors": [
+					{
+					  "message": "invalid_otp",
+					  "parameter": "otp",
+					  "value": ""
+					}
+				  ]
+				}
+			}`))
+
+			// return validation error
 			c.JSON(http.StatusBadRequest, structs.Map(response.StatusBadRequest{
 				Code:    400,
-				Message: "OTP token invalid",
-				Data:    "",
+				Message: "validation_failed",
+				Data:    jsonParsed,
 			}))
 			return
 		}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -23,6 +23,15 @@ func Contains(a string, values []string) bool {
 	return false
 }
 
+func Remove(a string, values []string) []string {
+	for i, v := range values {
+		if v == a {
+			return append(values[:i], values[i+1:]...)
+		}
+	}
+	return values
+}
+
 func EpochToHumanDate(epochTime int) string {
 	i, err := strconv.ParseInt(strconv.Itoa(epochTime), 10, 64)
 	if err != nil {


### PR DESCRIPTION
We need to show the recovery codes for 2fa to the user.

New `GET /2fa` response:
```json
{
  "code": 200,
  "data": {
    "codes": [
      "063452",
      "961091",
      "173890",
      "070282",
      "880459"
    ],
    "status": true
  },
  "message": "2FA set for this user"
}
```

Validation error on `POST /2fa/otp-verify`:
```json
{
  "code": 400,
  "data": {
    "validation": {
      "errors": [
        {
          "message": "invalid_otp",
          "parameter": "otp",
          "value": ""
        }
      ]
    }
  },
  "message": "validation_failed"
}
```