### PR TITLE
middleware. fix delimiter in flat/unflat map

### DIFF
--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -146,7 +146,10 @@ func InitJWT() *jwt.GinJWTMiddleware {
 				// convert to map and flat it
 				var jsonDyn map[string]interface{}
 				json.Unmarshal(body, &jsonDyn)
-				in, _ := flat.Flatten(jsonDyn, nil)
+				in, _ := flat.Flatten(jsonDyn, &flat.Options{
+					Delimiter: ".",
+					Safe:      true,
+				})
 
 				// search for sensitve data, in sensitive list
 				for k, _ := range in {


### PR DESCRIPTION
Added option on flat/unflat map to preserve original JSON payload structure.

Reference: https://trello.com/c/5dHdQL4M/305-nethsecurity-api-bad-log-of-payload