### PR TITLE
middleware: fix, do not log file content

### DIFF
--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -162,6 +162,10 @@ func InitJWT() *jwt.GinJWTMiddleware {
 				// compose req body
 				reqBody = jsonB
 			}
+			// if reqURI contains /files path, just replace the body with a static string to avoid logging the file content
+			if strings.Contains(reqURI, "/files") {
+				reqBody = "<file>"
+			}
 
 			logs.Logs.Println("[INFO][AUTH] authorization success for user " + claims["id"].(string) + ". " + reqMethod + " " + reqURI + " " + reqBody)
 

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -135,7 +135,11 @@ func InitJWT() *jwt.GinJWTMiddleware {
 
 			// extract body
 			reqBody := ""
-			if reqMethod == "POST" || reqMethod == "PUT" {
+			// if reqURI contains /files path, just replace the body with a static string to avoid logging the file content
+			if strings.Contains(reqURI, "/files") {
+				reqBody = "<file>"
+			}
+			if reqBody != "<file>" && (reqMethod == "POST" || reqMethod == "PUT") {
 				// extract body
 				var buf bytes.Buffer
 				tee := io.TeeReader(c.Request.Body, &buf)
@@ -161,10 +165,6 @@ func InitJWT() *jwt.GinJWTMiddleware {
 
 				// compose req body
 				reqBody = jsonB
-			}
-			// if reqURI contains /files path, just replace the body with a static string to avoid logging the file content
-			if strings.Contains(reqURI, "/files") {
-				reqBody = "<file>"
 			}
 
 			logs.Logs.Println("[INFO][AUTH] authorization success for user " + claims["id"].(string) + ". " + reqMethod + " " + reqURI + " " + reqBody)


### PR DESCRIPTION
Avoid flooding the log with the file content.
In case of big files, like images for upgrades,
procd seems to block if can't handle all the output.