### PR TITLE
Bypass rpcd

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/fatih/structs"
@@ -49,7 +49,7 @@ func main() {
 
 	// disable log to stdout when running in release mode
 	if gin.Mode() == gin.ReleaseMode {
-		gin.DefaultWriter = ioutil.Discard
+		gin.DefaultWriter = io.Discard
 	}
 
 	// init routers

--- a/main.go
+++ b/main.go
@@ -12,6 +12,9 @@ package main
 import (
 	"io"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/fatih/structs"
 	"github.com/gin-contrib/cors"
@@ -46,6 +49,19 @@ func main() {
 
 	// init configuration
 	configuration.Init()
+
+	// load list of valid paths
+	methods.LoadValidPaths()
+
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGUSR1)
+	go func() {
+		sig := <-sigs
+		if sig == syscall.SIGUSR1 {
+			logs.Logs.Println("Reloading valid path list")
+			methods.LoadValidPaths()
+		}
+	}()
 
 	// disable log to stdout when running in release mode
 	if gin.Mode() == gin.ReleaseMode {

--- a/methods/auth.go
+++ b/methods/auth.go
@@ -10,7 +10,6 @@
 package methods
 
 import (
-	"context"
 	"crypto/rand"
 	"encoding/base32"
 	"encoding/json"
@@ -36,8 +35,6 @@ import (
 	"github.com/NethServer/nethsecurity-api/response"
 	"github.com/NethServer/nethsecurity-api/utils"
 )
-
-var ctx = context.Background()
 
 func CheckAuthentication(username string, password string) error {
 	// define login object
@@ -146,7 +143,7 @@ func OTPVerify(c *gin.Context) {
 	}
 
 	// check if 2FA was disabled
-	status, err := os.ReadFile(configuration.Config.SecretsDir + "/" + jsonOTP.Username + "/status")
+	status, _ := os.ReadFile(configuration.Config.SecretsDir + "/" + jsonOTP.Username + "/status")
 	statusOld := strings.TrimSpace(string(status[:]))
 
 	// then clean all previous tokens
@@ -409,11 +406,7 @@ func SetTokenValidation(username string, token string) bool {
 	_, err := f.WriteString(token + "\n")
 
 	// check error
-	if err != nil {
-		return false
-	}
-
-	return true
+	return err == nil
 }
 
 func DelTokenValidation(username string, token string) bool {
@@ -435,12 +428,7 @@ func DelTokenValidation(username string, token string) bool {
 	_, err := f.WriteString(strings.TrimSpace(res) + "\n")
 
 	// check error
-	if err != nil {
-		return false
-	}
-
-	return true
-
+	return err == nil
 }
 
 func ValidateAuth(tokenString string, ensureTokenExists bool) bool {
@@ -449,7 +437,7 @@ func ValidateAuth(tokenString string, ensureTokenExists bool) bool {
 		token, err := jwtl.Parse(tokenString, func(token *jwtl.Token) (interface{}, error) {
 			// validate the alg
 			if _, ok := token.Method.(*jwtl.SigningMethodHMAC); !ok {
-				return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
+				return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 			}
 
 			// return secret
@@ -467,14 +455,14 @@ func ValidateAuth(tokenString string, ensureTokenExists bool) bool {
 					username := claims["id"].(string)
 
 					if !CheckTokenValidation(username, tokenString) {
-						logs.Logs.Println("[ERR][JWT] error JWT token not found: " + err.Error())
+						logs.Logs.Println("[ERR][JWT] error JWT token not found")
 						return false
 					}
 				}
 				return true
 			}
 		} else {
-			logs.Logs.Println("[ERR][JWT] error in JWT token claims: " + err.Error())
+			logs.Logs.Println("[ERR][JWT] error in JWT token claims")
 			return false
 		}
 	}
@@ -539,11 +527,7 @@ func UpdateRecoveryCodes(username string, codes []string) bool {
 	_, err := f.WriteString(strings.Join(codes[:], "\n"))
 
 	// check error
-	if err != nil {
-		return false
-	}
-
-	return true
+	return err == nil
 }
 
 func DeleteExpiredTokens() {

--- a/methods/auth.go
+++ b/methods/auth.go
@@ -390,7 +390,7 @@ func SetUserSecret(username string, secret string) (bool, string) {
 
 func CheckTokenValidation(username string, token string) bool {
 	// read whole file
-	secrestListB, err := ioutil.ReadFile(configuration.Config.TokensDir + "/" + username)
+	secrestListB, err := os.ReadFile(configuration.Config.TokensDir + "/" + username)
 	if err != nil {
 		return false
 	}

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -12,7 +12,6 @@ package middleware
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"regexp"
 	"strings"
 	"time"
@@ -143,8 +142,8 @@ func InitJWT() *jwt.GinJWTMiddleware {
 				// extract body
 				var buf bytes.Buffer
 				tee := io.TeeReader(c.Request.Body, &buf)
-				body, _ := ioutil.ReadAll(tee)
-				c.Request.Body = ioutil.NopCloser(&buf)
+				body, _ := io.ReadAll(tee)
+				c.Request.Body = io.NopCloser(&buf)
 
 				// get JSON string body
 				jsonB := string(body)


### PR DESCRIPTION
rpcd has some limitations on script execution timeout and on the amount of transferred data

This changes try to overcome these limitations:
- execute all `ns.<api>` scripts without rpcd
- setup a fall-back mode to use rpcd for old non-ns APIs
- do not stop script execution after a timeout
- no limit on the size of returned data

When rpcd is bypassed, each API call can spare about 1 millisecond of time.

Drawbacks of the new implementation:
- direct script execution could lead to possible security issue, see [commit message](https://github.com/NethServer/nethsecurity-api/commit/3ae28b0f8fc1573c33bbee36ae768073d875fbde) for the countermeasures; the API server must be reloaded with a SIGUSR1 when a new API is added
- any authenticated user can execute all commands: rpcd authorization profiles are ignored (still, they are really not used even right now so no real change on this side)


Ref: Nethserver/nethsecurity#687