### PR TITLE
ubus: ignore JSON parse error

### DIFF
--- a/methods/ubus.go
+++ b/methods/ubus.go
@@ -114,15 +114,7 @@ func UBusCallAction(c *gin.Context) {
 	}
 
 	// parse output in a valid JSON
-	jsonParsed, err := gabs.ParseJSON(out)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, structs.Map(response.StatusBadRequest{
-			Code:    500,
-			Message: "invalid JSON response",
-			Data:    jsonParsed,
-		}))
-		return
-	}
+	jsonParsed, _ := gabs.ParseJSON(out)
 
 	// check errors in response
 	errorMessage, errFound := jsonParsed.Path("error").Data().(string)


### PR DESCRIPTION
The gabs library can sometimes fail to decode
a valid JSON.

Regression introduced by 2f2706bd629c2609d180ce356d39f189aa83e666