### PR TITLE
ubus: remove valid path list feature

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,9 +12,6 @@ package main
 import (
 	"io"
 	"net/http"
-	"os"
-	"os/signal"
-	"syscall"
 
 	"github.com/fatih/structs"
 	"github.com/gin-contrib/cors"
@@ -49,21 +46,6 @@ func main() {
 
 	// init configuration
 	configuration.Init()
-
-	// load list of valid paths
-	methods.LoadValidPaths()
-
-	// prepare signal handling
-	sigs := make(chan os.Signal, 1)
-	wait_sigs := make(chan bool, 1)
-	signal.Notify(sigs, syscall.SIGUSR1)
-	go func() {
-		sig := <-sigs
-		if sig == syscall.SIGUSR1 {
-			logs.Logs.Println("Reloading valid path list")
-			methods.LoadValidPaths()
-		}
-	}()
 
 	// disable log to stdout when running in release mode
 	if gin.Mode() == gin.ReleaseMode {
@@ -134,7 +116,4 @@ func main() {
 
 	// run server
 	router.Run(configuration.Config.ListenAddress)
-
-	// wait for signals: this is blocking and must be called after router.Run
-	<-wait_sigs
 }


### PR DESCRIPTION
This feature is prone to error: if the server is not restarted or reloaded after a new API has been added, clients will face a 400 error even if the API is legit

NethServer/nethsecurity#810