### PR TITLE
middleware: log client IP on login

### DIFF
--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -66,15 +66,15 @@ func InitJWT() *jwt.GinJWTMiddleware {
 			// check login
 			err := methods.CheckAuthentication(username, password)
 			if err != nil {
-				// login fail action
-				logs.Logs.Println("[INFO][AUTH] authentication failed for user " + username + ": " + err.Error())
+				// login failed, write also the IP address of the client
+				logs.Logs.Println("[INFO][AUTH] authentication failed for user " + username + " from " + c.ClientIP() + ": " + err.Error())
 
 				// return JWT error
 				return nil, jwt.ErrFailedAuthentication
 			}
 
 			// login ok action
-			logs.Logs.Println("[INFO][AUTH] authentication success for user " + username)
+			logs.Logs.Println("[INFO][AUTH] authentication success for user " + username + " from " + c.ClientIP())
 
 			// return user auth model
 			return &models.UserAuthorizations{


### PR DESCRIPTION
On failed login, the IP address could be used by security tools to block attackers.

Log example:
```
Oct  2 10:49:07 NethSec nethsecurity-api[9742]: nethsecurity_api 2024/10/02 10:49:07 middleware.go:70: [INFO][AUTH] authentication failed for user a from 192.168.100.1: exit status 250
...
Oct  2 10:57:51 NethSec nethsecurity-api[11918]: nethsecurity_api 2024/10/02 10:57:51 middleware.go:77: [INFO][AUTH] authentication success for user root from 192.168.100.1
```

See also:
- NethServer/nethsecurity#795
- https://github.com/NethServer/nethsecurity/pull/793