### PR TITLE
fix: if recovery codes haven't been generated, don't throw error

### DIFF
--- a/methods/auth.go
+++ b/methods/auth.go
@@ -292,12 +292,15 @@ func Del2FAStatus(c *gin.Context) {
 	// revocate recovery codes
 	errRevocateCodes := os.Remove(configuration.Config.SecretsDir + "/" + claims["id"].(string) + "/codes")
 	if errRevocateCodes != nil {
-		c.JSON(http.StatusBadRequest, structs.Map(response.StatusBadRequest{
-			Code:    403,
-			Message: "error in delete 2FA recovery codes",
-			Data:    nil,
-		}))
-		return
+		// if the file does not exist, it is ok, skip the error
+		if !os.IsNotExist(errRevocateCodes) {
+			c.JSON(http.StatusBadRequest, structs.Map(response.StatusBadRequest{
+				Code:    403,
+				Message: "error in delete 2FA recovery codes",
+				Data:    nil,
+			}))
+			return
+		}
 	}
 
 	// set 2FA to disabled


### PR DESCRIPTION
Ref: https://github.com/NethServer/nethsecurity/issues/1164

