### PR TITLE
feat(ubus): log detailed for  errors in UBusCallAction

### DIFF
--- a/methods/ubus.go
+++ b/methods/ubus.go
@@ -97,6 +97,7 @@ func UBusCallAction(c *gin.Context) {
 	if err != nil {
 		// log full response for debugging if ubus call fails
 		logs.Logs.Println("[ERROR][UBUS][PROCESS] ubus execution error:", err.Error())
+		logs.Logs.Println("[ERROR][UBUS][OUTPUT] ubus execution output:", string(out))
 		c.JSON(http.StatusInternalServerError, structs.Map(response.StatusBadRequest{
 			Code:    500,
 			Message: "ubus call action failed",

--- a/methods/ubus.go
+++ b/methods/ubus.go
@@ -14,10 +14,11 @@ import (
 	"io"
 	"net/http"
 	"os/exec"
+	"fmt"
 
 	"github.com/NethServer/nethsecurity-api/models"
 	"github.com/NethServer/nethsecurity-api/response"
-
+	"github.com/NethServer/nethsecurity-api/logs"
 	"github.com/Jeffail/gabs/v2"
 	"github.com/fatih/structs"
 	"github.com/gin-gonic/gin"
@@ -49,6 +50,8 @@ func UBusCallAction(c *gin.Context) {
 		// execute direct script call
 		stdin, err := cmd.StdinPipe()
 		if err != nil {
+			// log full response for debugging if ubus call fails
+			logs.Logs.Println("[ERROR][UBUS][STDIN] ubus stdin pipe error:", err.Error())
 			c.JSON(http.StatusInternalServerError, structs.Map(response.StatusBadRequest{
 				Code:    500,
 				Message: "ubus call action failed",
@@ -92,6 +95,8 @@ func UBusCallAction(c *gin.Context) {
 	// check errors
 	out, err := cmd.CombinedOutput()
 	if err != nil {
+		// log full response for debugging if ubus call fails
+		logs.Logs.Println("[ERROR][UBUS][PROCESS] ubus execution error:", err.Error())
 		c.JSON(http.StatusInternalServerError, structs.Map(response.StatusBadRequest{
 			Code:    500,
 			Message: "ubus call action failed",
@@ -106,6 +111,12 @@ func UBusCallAction(c *gin.Context) {
 	// check errors in response
 	errorMessage, errFound := jsonParsed.Path("error").Data().(string)
 	if errFound {
+		// log full response for debugging if we find {"error": ...} in response
+		logs.Logs.Println(fmt.Sprintf(
+			"[ERROR][UBUS][RESPONSE] ubus application error: Message='%s', Data='%s'",
+			errorMessage,
+			jsonParsed.String(),
+		))
 		c.JSON(http.StatusInternalServerError, structs.Map(response.StatusBadRequest{
 			Code:    500,
 			Message: errorMessage,


### PR DESCRIPTION
This pull request introduces improved error logging for the `UBusCallAction` method in the `methods/ubus.go` file. The main change is the addition of detailed log messages to help diagnose failures when executing UBUS-related actions.

Error logging enhancements:

* Added import of the `logs` package to enable logging within the file.
* Added error log messages for failures when creating a stdin pipe for the command (`cmd.StdinPipe`).
* Added error log messages for failures when executing the command and capturing combined output (`cmd.CombinedOutput`).
* Added error log messages for UBUS call errors detected in the parsed JSON response.

https://github.com/NethServer/nethsecurity/issues/1288

```
Sep 30 13:59:37 NethSec nethsecurity-api[10741]: nethsecurity_api 2025/09/30 13:59:37 middleware.go:178: [INFO][AUTH] authorization success for user root. POST /api/ubus/call {"path":"ns.objects","method":"add-host-set","payload":{"name":"xcvcxv","family":"ipv4","ipaddr":["objects/ns_512f1437"]}}
Sep 30 13:59:37 NethSec nethsecurity-api[10741]: nethsecurity_api 2025/09/30 13:59:37 ubus.go:56: [ERROR][UBUS][STDIN] ubus stdin pipe error: exec: Stdin already set
Sep 30 13:59:37 NethSec nginx: 192.168.61.1 - - [30/Sep/2025:13:59:37 +0000] "POST /api/ubus/call HTTP/1.1" 500 99 "https://192.168.61.134:9090/" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36"
```

```
Sep 30 10:45:03 NethSec nethsecurity-api[4946]: nethsecurity_api 2025/09/30 10:45:03 middleware.go:178: [INFO][AUTH] authorization success for user root. POST /api/ubus/call {"path":"ns.objects","method":"add-host-set","payload":{"name":"bbbbbbbbbbbbbbbb","family":"ipv4","ipaddr":["1.2.3.4"]}}
Sep 30 10:45:03 NethSec nethsecurity-api[4946]: nethsecurity_api 2025/09/30 10:45:03 ubus.go:97: [ERROR][UBUS][PROCESS] ubus execution error: fork/exec /usr/libexec/rpcd/ns.objects: no such file or directory
Sep 30 10:45:03 NethSec nginx: 192.168.61.1 - - [30/Sep/2025:10:45:03 +0000] "POST /api/ubus/call HTTP/1.1" 500 125 "https://192.168.61.134:9090/" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36"
```

```
Sep 30 13:29:23 NethSec nethsecurity-api[4946]: nethsecurity_api 2025/09/30 13:29:23 middleware.go:178: [INFO][AUTH] authorization success for user root. POST /api/ubus/call {"path":"ns.objects","method":"add-host-set","payload":{"name":"cvcxv","family":"ipv4","ipaddr":["objects/ns_e5387b4c"]}}
Sep 30 13:29:23 NethSec nethsecurity-api[4946]: nethsecurity_api 2025/09/30 13:29:23 ubus.go:112: [ERROR][UBUS][RESPONSE] ubus application error: Message='something went wrong', Data='{"error":"something went wrong"}'
Sep 30 13:29:23 NethSec nginx: 192.168.61.1 - - [30/Sep/2025:13:29:23 +0000] "POST /api/ubus/call HTTP/1.1" 500 86 "https://192.168.61.134:9090/" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36"
```